### PR TITLE
Fix errors in Route53 provider

### DIFF
--- a/lib/puppet/provider/dns_record/route53.rb
+++ b/lib/puppet/provider/dns_record/route53.rb
@@ -27,8 +27,8 @@ module Route53
       @@zone ||= Fog::DNS.new({ :provider => "aws",
                                 :aws_access_key_id => @username,
                                 :aws_secret_access_key => @password } )
-   end
- end
+    end
+  end
 end
 
 Puppet::Type.type(:dns_record).provide(:route53) do
@@ -49,7 +49,7 @@ Puppet::Type.type(:dns_record).provide(:route53) do
 
     begin
       Puppet.debug("Attempting to create record type #{resource[:type]} for #{resource[:name]} as #{resource[:content]}")
-      record = @zone.records.create( :name  => resource[:name],
+      @zone.records.create( :name  => resource[:name],
                                      :value => resource[:content],
                                      :type  => resource[:type],
                                      :ttl   => resource[:ttl] )


### PR DESCRIPTION
Hi,

I stumbled upon a bug in the `route53` provider, where managed records kept being destroyed and re-created on every Puppet run, even though they were correct in the actual DNS zone. This PR contains the fix that works for me.

I split the patch into several commits: one cosmetic, one for the actual fix, and one with the changes in debug/info messages that helped me identify the problem.